### PR TITLE
minor JSON parse bugfix

### DIFF
--- a/src/constants/token/pancakeswap.json
+++ b/src/constants/token/pancakeswap.json
@@ -23,7 +23,7 @@
       "symbol": "WBNB",
       "address": "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 18
     },
     {
       "name": "LP3 Token",


### PR DESCRIPTION
yarn start error:

"Module parse failed: Unexpected token } in JSON at position 623 while parsing near '..."decimals": 18,"

fix:
unnecessary "," removed.

