### PR TITLE
Error handling on Crowdin API Query fetch catch & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Or, to run Cypress with its GUI
 yarn cypress open
 ```
 
-## Localisation
+# Localisation
+
+_In order for the Crowdin API queries to work - you will need `REACT_APP_CROWDIN_APIKEY` & `REACT_APP_CROWDIN_PROJECTID` env variables set in your root `.env.development.local` file - please contact a dev if you need these._
 
 ### Adding translations
 
 There are two methods for adding translations, both are valid, and it depends on the context in which you are trying to implement the translation as to which you should use.
 
-1. Using `TranslateString` within `translateTextHelpers`
+#### 1. Using `TranslateString` within `translateTextHelpers`
 
 If you need to translate a string that exists within another string, i.e:
-
-**a.**
 
 ```js
 <span>I need to translate this bit of the span. I don't need to translate this second sentence.</span>
@@ -67,31 +67,25 @@ If you need to translate a string that exists within another string, i.e:
 
 Or, a string that is being passed into a component as props, i.e.:
 
-**b.**
-
 ```js
 <Component label="This text need translated" />
 ```
 
 Then you should make use of the `TranslateString` method within `translateTextHelpers`.
 
-It takes in the `translationId` (found in Crowdin) as the first argument, and a string of fallback text as the second argument, which is rendered if the translation isn't found, i.e.:
-
-**a.**
+It takes in the `translationId` (found in Crowdin) as the first argument, and a string of fallback text as the second argument, which is rendered if the translation isn't found,
 
 ```js
 import { TranslateString } from '../translateTextHelpers'
 ;<StyledLink>🍯 {TranslateString(282, 'SYRUP Pool')}</StyledLink>
 ```
 
-**b.**
-
 ```js
 import { TranslateString } from '../translateTextHelpers'
 ;<Button text={`🔓 ${TranslateString(292, 'Unlock Wallet')}`} />
 ```
 
-2. Using `TranslatedText` component
+#### 2. Using `TranslatedText` component
 
 This is a simple abstraction of the `TranslateString` method, wrapping it within a React Component - this can be a visually simpler pattern, if you are wanting to translate standalone piece of text.
 

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -116,7 +116,10 @@ export default function App() {
         }
       })
       .then(() => setTranslatedLanguage(selectedLanguage))
-      .catch(error => console.error(error))
+      .catch(error => {
+        setTranslations(['error'])
+        console.error(error)
+      })
   }
 
   useEffect(() => {


### PR DESCRIPTION
- Added error handling for when the Crowdin API query errors:

```
      .catch(error => {
        setTranslations(['error'])
        console.error(error)
      })
```

Which means that the `translateString` function will return the `fallback` text if it errors

- Updated readme