### PR TITLE
fix: Allow slippage to be a float. Fixes 174

### DIFF
--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -74,7 +74,7 @@ function useSwapCallArguments(
           // @ts-ignore
           Router.swapCallParameters(trade, {
             feeOnTransfer: false,
-            allowedSlippage: new Percent(JSBI.BigInt(allowedSlippage), BIPS_BASE),
+            allowedSlippage: new Percent(JSBI.BigInt(Math.floor(allowedSlippage)), BIPS_BASE),
             recipient,
             ttl: deadline,
           })
@@ -85,7 +85,7 @@ function useSwapCallArguments(
             // @ts-ignore
             Router.swapCallParameters(trade, {
               feeOnTransfer: true,
-              allowedSlippage: new Percent(JSBI.BigInt(allowedSlippage), BIPS_BASE),
+              allowedSlippage: new Percent(JSBI.BigInt(Math.floor(allowedSlippage)), BIPS_BASE),
               recipient,
               ttl: deadline,
             })
@@ -96,7 +96,7 @@ function useSwapCallArguments(
         swapMethods.push(
           // @ts-ignore
           v1SwapArguments(trade, {
-            allowedSlippage: new Percent(JSBI.BigInt(allowedSlippage), BIPS_BASE),
+            allowedSlippage: new Percent(JSBI.BigInt(Math.floor(allowedSlippage)), BIPS_BASE),
             recipient,
             ttl: deadline,
           })
@@ -215,11 +215,10 @@ export function useSwapCallback(
             const withRecipient =
               recipient === account
                 ? base
-                : `${base} to ${
-                    recipientAddressOrName && isAddress(recipientAddressOrName)
-                      ? shortenAddress(recipientAddressOrName)
-                      : recipientAddressOrName
-                  }`
+                : `${base} to ${recipientAddressOrName && isAddress(recipientAddressOrName)
+                  ? shortenAddress(recipientAddressOrName)
+                  : recipientAddressOrName
+                }`
 
             const withVersion =
               tradeVersion === Version.v2 ? withRecipient : `${withRecipient} on ${(tradeVersion as any).toUpperCase()}`

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -97,6 +97,7 @@ describe('utils', () => {
       expect(basisPointsToPercent(100).equalTo(new Percent(JSBI.BigInt(1), JSBI.BigInt(100)))).toBeTruthy()
       expect(basisPointsToPercent(500).equalTo(new Percent(JSBI.BigInt(5), JSBI.BigInt(100)))).toBeTruthy()
       expect(basisPointsToPercent(50).equalTo(new Percent(JSBI.BigInt(5), JSBI.BigInt(1000)))).toBeTruthy()
+      expect(basisPointsToPercent(110.00000000000001).equalTo(new Percent(JSBI.BigInt(110), JSBI.BigInt(10000)))).toBeTruthy()
     })
   })
 })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -55,7 +55,7 @@ export function calculateGasMargin(value: BigNumber): BigNumber {
 
 // converts a basis points value to a sdk percent
 export function basisPointsToPercent(num: number): Percent {
-  return new Percent(JSBI.BigInt(num), JSBI.BigInt(10000))
+  return new Percent(JSBI.BigInt(Math.floor(num)), JSBI.BigInt(10000))
 }
 
 export function calculateSlippageAmount(value: CurrencyAmount, slippage: number): [JSBI, JSBI] {


### PR DESCRIPTION
Fixes https://github.com/pancakeswap/pancake-swap-interface/issues/174

`allowedSlippage` can be a float, but `JSBI.BigInt` only accepts integers, used `Math.floor()` to convert it to the greatest integer less than or equal to its numeric argument.