### PR TITLE
chore: Update BTCST decimals

### DIFF
--- a/src/constants/token/pancakeswap.json
+++ b/src/constants/token/pancakeswap.json
@@ -548,7 +548,7 @@
       "symbol": "BTCST",
       "address": "0x78650b139471520656b9e7aa7a5e9276814a38e9",
       "chainId": 56,
-      "decimals": 18
+      "decimals": 17
     },
     {
       "name": "Frontier Token",


### PR DESCRIPTION
BTCST are removing one decimal from their token
https://btcst.medium.com/btcst-redenomination-guide-for-exchange-and-wallet-partners-ad00eade8cec
