### PR TITLE
Add BTCB as a base routing pair

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ type ChainTokenList = {
 
 export const DAI = new Token(ChainId.MAINNET, '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3', 18, 'DAI', 'Dai Stablecoin')
 export const BUSD = new Token(ChainId.MAINNET, '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56', 18, 'BUSD', 'Binance USD')
+export const BTCB = new Token(ChainId.MAINNET, '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c', 18, 'BTCB', 'Binance BTC')
 export const USDT = new Token(ChainId.MAINNET, '0x55d398326f99059fF775485246999027B3197955', 18, 'USDT', 'Tether USD')
 export const UST = new Token(
   ChainId.MAINNET,
@@ -33,7 +34,7 @@ const WETH_ONLY: ChainTokenList = {
 // used to construct intermediary pairs for trading
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, BUSD, USDT, UST, ETH],
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, BUSD, BTCB, USDT, UST, ETH],
 }
 
 /**
@@ -53,7 +54,7 @@ export const SUGGESTED_BASES: ChainTokenList = {
 // used to construct the list of all pairs we consider by default in the frontend
 export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, BUSD, USDT],
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, BUSD, BTCB, USDT],
 }
 
 export const PINNED_PAIRS: { readonly [chainId in ChainId]?: [Token, Token][] } = {


### PR DESCRIPTION
Badger native tokens bBADGER and bDIGG are paired with BTCb via cake incentivised pools.   Currently, one can not buy these tokens with anything but BTCb without high slippage.  We also had this problem with SushiSwap and Uniswap, and know that this is because BTCb is one of the base tokens.  This PR adds it as such.  Both SUSHI and Uni have already merged similar pull requests.


[X] Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-swap-interface/blob/master/CONTRIBUTING.md) first
[X ] If your PR is work in progress, open it as `draft`
[X] Before requesting a review, all the checks need to pass
[X ] Explain what your PR does
