### PR TITLE
fix(menu): Competition href

### DIFF
--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -44,7 +44,7 @@ const config: MenuEntry[] = [
   {
     label: 'Team Battle',
     icon: 'TeamBattleIcon',
-    href: '/competition',
+    href: 'https://pancakeswap.finance/competition',
     status: menuStatus.SOON,
   },
   {


### PR DESCRIPTION
Redirect to the competition page using an absolute URI instead of relative (different repository).