### PR TITLE
Feature/audio toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@crowdin/crowdin-api-client": "^1.8.16",
     "@ethersproject/experimental": "^5.0.1",
     "@pancakeswap-libs/sdk": "1.0.1",
-    "@pancakeswap-libs/uikit": "^0.22.0",
+    "@pancakeswap-libs/uikit": "^0.23.0",
     "@popperjs/core": "^2.4.4",
     "@reach/dialog": "^0.10.3",
     "@reach/portal": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@crowdin/crowdin-api-client": "^1.8.16",
     "@ethersproject/experimental": "^5.0.1",
     "@pancakeswap-libs/sdk": "1.0.1",
-    "@pancakeswap-libs/uikit": "^0.20.0",
+    "@pancakeswap-libs/uikit": "^0.22.0",
     "@popperjs/core": "^2.4.4",
     "@reach/dialog": "^0.10.3",
     "@reach/portal": "^0.10.3",

--- a/src/components/PageHeader/AudioSetting.tsx
+++ b/src/components/PageHeader/AudioSetting.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Input, Text, Toggle } from '@pancakeswap-libs/uikit'
+import { Input, Text, PancakeToggle, useMatchBreakpoints } from '@pancakeswap-libs/uikit'
 import { useAudioModeManager } from 'state/user/hooks'
 
 const StyledAudioSetting = styled.div`
@@ -32,6 +32,7 @@ type AudioSettingModalProps = {
 }
 
 const AudioSetting = ({ translateString }: AudioSettingModalProps) => {
+  const { isSm, isXs } = useMatchBreakpoints()
   const [audioPlay, toggleSetAudioMode] = useAudioModeManager()
 
   return (
@@ -40,7 +41,7 @@ const AudioSetting = ({ translateString }: AudioSettingModalProps) => {
         <Text style={{ fontWeight: 600 }}>{translateString(999, 'Audio')}</Text>
       </Label>
       <Field>
-        <Toggle checked={audioPlay} onClick={toggleSetAudioMode} />
+        <PancakeToggle scale={isSm || isXs ? 'sm' : 'md'} checked={audioPlay} onChange={toggleSetAudioMode} />
       </Field>
     </StyledAudioSetting>
   )

--- a/src/components/PageHeader/AudioSetting.tsx
+++ b/src/components/PageHeader/AudioSetting.tsx
@@ -1,31 +1,6 @@
 import React from 'react'
-import styled from 'styled-components'
-import { Input, Text, PancakeToggle, useMatchBreakpoints } from '@pancakeswap-libs/uikit'
+import { Box, Flex, Text, PancakeToggle, useMatchBreakpoints } from '@pancakeswap-libs/uikit'
 import { useAudioModeManager } from 'state/user/hooks'
-
-const StyledAudioSetting = styled.div`
-  margin-bottom: 16px;
-`
-
-const Label = styled.div`
-  align-items: center;
-  display: flex;
-  margin-bottom: 8px;
-`
-
-const Field = styled.div`
-  align-items: center;
-  display: inline-flex;
-
-  & > ${Input} {
-    max-width: 100px;
-  }
-
-  & > ${Text} {
-    font-size: 14px;
-    margin-left: 8px;
-  }
-`
 
 type AudioSettingModalProps = {
   translateString: (translationId: number, fallback: string) => string
@@ -36,14 +11,14 @@ const AudioSetting = ({ translateString }: AudioSettingModalProps) => {
   const [audioPlay, toggleSetAudioMode] = useAudioModeManager()
 
   return (
-    <StyledAudioSetting>
-      <Label>
-        <Text style={{ fontWeight: 600 }}>{translateString(999, 'Audio')}</Text>
-      </Label>
-      <Field>
+    <Box mb="16px">
+      <Flex alignItems="center" mb="8px">
+        <Text bold>{translateString(999, 'Audio')}</Text>
+      </Flex>
+      <Box>
         <PancakeToggle scale={isSm || isXs ? 'sm' : 'md'} checked={audioPlay} onChange={toggleSetAudioMode} />
-      </Field>
-    </StyledAudioSetting>
+      </Box>
+    </Box>
   )
 }
 

--- a/src/components/PageHeader/AudioSetting.tsx
+++ b/src/components/PageHeader/AudioSetting.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Input, Text, Toggle } from '@pancakeswap-libs/uikit'
+import { useAudioModeManager } from 'state/user/hooks'
+
+const StyledAudioSetting = styled.div`
+  margin-bottom: 16px;
+`
+
+const Label = styled.div`
+  align-items: center;
+  display: flex;
+  margin-bottom: 8px;
+`
+
+const Field = styled.div`
+  align-items: center;
+  display: inline-flex;
+
+  & > ${Input} {
+    max-width: 100px;
+  }
+
+  & > ${Text} {
+    font-size: 14px;
+    margin-left: 8px;
+  }
+`
+
+type AudioSettingModalProps = {
+  translateString: (translationId: number, fallback: string) => string
+}
+
+const AudioSetting = ({ translateString }: AudioSettingModalProps) => {
+  const [audioPlay, toggleSetAudioMode] = useAudioModeManager()
+
+  return (
+    <StyledAudioSetting>
+      <Label>
+        <Text style={{ fontWeight: 600 }}>{translateString(999, 'Audio')}</Text>
+      </Label>
+      <Field>
+        <Toggle checked={audioPlay} onClick={toggleSetAudioMode} />
+      </Field>
+    </StyledAudioSetting>
+  )
+}
+
+export default AudioSetting

--- a/src/components/PageHeader/RecentTransactionsModal.tsx
+++ b/src/components/PageHeader/RecentTransactionsModal.tsx
@@ -8,7 +8,7 @@ import Loader from 'components/Loader'
 
 type RecentTransactionsModalProps = {
   onDismiss?: () => void
-  translateString: (translationId: number, fallback: string) => (string)
+  translateString: (translationId: number, fallback: string) => string
 }
 
 // TODO: Fix UI Kit typings
@@ -31,7 +31,6 @@ const getRowStatus = (sortedRecentTransaction: TransactionDetails) => {
 }
 
 const RecentTransactionsModal = ({ onDismiss = defaultOnDismiss, translateString }: RecentTransactionsModalProps) => {
-  const TranslateString = translateString
   const { account, chainId } = useActiveWeb3React()
   const allTransactions = useAllTransactions()
 
@@ -42,7 +41,7 @@ const RecentTransactionsModal = ({ onDismiss = defaultOnDismiss, translateString
   }, [allTransactions])
 
   return (
-    <Modal title={TranslateString(1202, 'Recent transactions')} onDismiss={onDismiss}>
+    <Modal title={translateString(1202, 'Recent transactions')} onDismiss={onDismiss}>
       {!account && (
         <Flex justifyContent="center" flexDirection="column" alignItems="center">
           <Text mb="8px" bold>

--- a/src/components/PageHeader/SettingsModal.tsx
+++ b/src/components/PageHeader/SettingsModal.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 import { Modal } from '@pancakeswap-libs/uikit'
 import SlippageToleranceSetting from './SlippageToleranceSetting'
 import TransactionDeadlineSetting from './TransactionDeadlineSetting'
+import AudioSetting from './AudioSetting'
 
 type SettingsModalProps = {
-  onDismiss?: () => void,
-  translateString: (translationId: number, fallback: string) => (string)
+  onDismiss?: () => void
+  translateString: (translationId: number, fallback: string) => string
 }
 
 // TODO: Fix UI Kit typings
@@ -14,8 +15,9 @@ const defaultOnDismiss = () => null
 const SettingsModal = ({ onDismiss = defaultOnDismiss, translateString }: SettingsModalProps) => {
   return (
     <Modal title={translateString(1200, 'Settings')} onDismiss={onDismiss}>
-      <SlippageToleranceSetting translateString={translateString}/>
-      <TransactionDeadlineSetting translateString={translateString}/>
+      <SlippageToleranceSetting translateString={translateString} />
+      <TransactionDeadlineSetting translateString={translateString} />
+      <AudioSetting translateString={translateString} />
     </Modal>
   )
 }

--- a/src/components/PageHeader/SlippageToleranceSetting.tsx
+++ b/src/components/PageHeader/SlippageToleranceSetting.tsx
@@ -95,7 +95,7 @@ const SlippageToleranceSettings = ({ translateString }: SlippageToleranceSetting
         />
       </Label>
       <Options>
-        <Flex mb={['8px', 0]} mr={[0, '8px']}>
+        <Flex mb={['8px', '8px', 0]} mr={[0, 0, '8px']}>
           {predefinedValues.map(({ label, value: predefinedValue }) => {
             const handleClick = () => setValue(predefinedValue)
 

--- a/src/components/PageHeader/SlippageToleranceSetting.tsx
+++ b/src/components/PageHeader/SlippageToleranceSetting.tsx
@@ -47,11 +47,10 @@ const predefinedValues = [
 ]
 
 type SlippageToleranceSettingsModalProps = {
-  translateString: (translationId: number, fallback: string) => (string)
+  translateString: (translationId: number, fallback: string) => string
 }
 
 const SlippageToleranceSettings = ({ translateString }: SlippageToleranceSettingsModalProps) => {
-  const TranslateString = translateString
   const [userSlippageTolerance, setUserslippageTolerance] = useUserSlippageTolerance()
   const [value, setValue] = useState(userSlippageTolerance / 100)
   const [error, setError] = useState<string | null>(null)
@@ -68,28 +67,28 @@ const SlippageToleranceSettings = ({ translateString }: SlippageToleranceSetting
         setUserslippageTolerance(rawValue)
         setError(null)
       } else {
-        setError(TranslateString(1144, 'Enter a valid slippage percentage'))
+        setError(translateString(1144, 'Enter a valid slippage percentage'))
       }
     } catch {
-      setError(TranslateString(1144, 'Enter a valid slippage percentage'))
+      setError(translateString(1144, 'Enter a valid slippage percentage'))
     }
-  }, [value, setError, setUserslippageTolerance, TranslateString])
+  }, [value, setError, setUserslippageTolerance, translateString])
 
   // Notify user if slippage is risky
   useEffect(() => {
     if (userSlippageTolerance < RISKY_SLIPPAGE_LOW) {
-      setError(TranslateString(1146, 'Your transaction may fail'))
+      setError(translateString(1146, 'Your transaction may fail'))
     } else if (userSlippageTolerance > RISKY_SLIPPAGE_HIGH) {
-      setError(TranslateString(1148, 'Your transaction may be frontrun'))
+      setError(translateString(1148, 'Your transaction may be frontrun'))
     }
-  }, [userSlippageTolerance, setError, TranslateString])
+  }, [userSlippageTolerance, setError, translateString])
 
   return (
     <StyledSlippageToleranceSettings>
       <Label>
-        <Text style={{ fontWeight: 600 }}>{TranslateString(88, 'Slippage tolerance')}</Text>
+        <Text style={{ fontWeight: 600 }}>{translateString(88, 'Slippage tolerance')}</Text>
         <QuestionHelper
-          text={TranslateString(
+          text={translateString(
             186,
             'Your transaction will revert if the price changes unfavorably by more than this percentage.'
           )}

--- a/src/components/PageHeader/SlippageToleranceSetting.tsx
+++ b/src/components/PageHeader/SlippageToleranceSetting.tsx
@@ -1,16 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { Button, Flex, Input, Text } from '@pancakeswap-libs/uikit'
+import { Box, Button, Flex, Input, Text } from '@pancakeswap-libs/uikit'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import QuestionHelper from '../QuestionHelper'
 
 const MAX_SLIPPAGE = 5000
 const RISKY_SLIPPAGE_LOW = 50
 const RISKY_SLIPPAGE_HIGH = 500
-
-const StyledSlippageToleranceSettings = styled.div`
-  margin-bottom: 16px;
-`
 
 const Option = styled.div`
   padding: 0 4px;
@@ -32,12 +28,6 @@ const Options = styled.div`
   ${({ theme }) => theme.mediaQueries.sm} {
     flex-direction: row;
   }
-`
-
-const Label = styled.div`
-  align-items: center;
-  display: flex;
-  margin-bottom: 8px;
 `
 
 const predefinedValues = [
@@ -84,16 +74,16 @@ const SlippageToleranceSettings = ({ translateString }: SlippageToleranceSetting
   }, [userSlippageTolerance, setError, translateString])
 
   return (
-    <StyledSlippageToleranceSettings>
-      <Label>
-        <Text style={{ fontWeight: 600 }}>{translateString(88, 'Slippage tolerance')}</Text>
+    <Box mb="16px">
+      <Flex alignItems="center" mb="8px">
+        <Text bold>{translateString(88, 'Slippage tolerance')}</Text>
         <QuestionHelper
           text={translateString(
             186,
             'Your transaction will revert if the price changes unfavorably by more than this percentage.'
           )}
         />
-      </Label>
+      </Flex>
       <Options>
         <Flex mb={['8px', '8px', 0]} mr={[0, 0, '8px']}>
           {predefinedValues.map(({ label, value: predefinedValue }) => {
@@ -131,7 +121,7 @@ const SlippageToleranceSettings = ({ translateString }: SlippageToleranceSetting
           {error}
         </Text>
       )}
-    </StyledSlippageToleranceSettings>
+    </Box>
   )
 }
 

--- a/src/components/PageHeader/TransactionDeadlineSetting.tsx
+++ b/src/components/PageHeader/TransactionDeadlineSetting.tsx
@@ -1,18 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { Input, Text } from '@pancakeswap-libs/uikit'
+import { Input, Text, Flex, Box } from '@pancakeswap-libs/uikit'
 import { useUserDeadline } from 'state/user/hooks'
 import QuestionHelper from '../QuestionHelper'
-
-const StyledTransactionDeadlineSetting = styled.div`
-  margin-bottom: 16px;
-`
-
-const Label = styled.div`
-  align-items: center;
-  display: flex;
-  margin-bottom: 8px;
-`
 
 const Field = styled.div`
   align-items: center;
@@ -20,11 +10,6 @@ const Field = styled.div`
 
   & > ${Input} {
     max-width: 100px;
-  }
-
-  & > ${Text} {
-    font-size: 14px;
-    margin-left: 8px;
   }
 `
 
@@ -58,23 +43,25 @@ const TransactionDeadlineSetting = ({ translateString }: TransactionDeadlineSett
   }, [value, setError, setDeadline, translateString])
 
   return (
-    <StyledTransactionDeadlineSetting>
-      <Label>
-        <Text style={{ fontWeight: 600 }}>{translateString(90, 'Transaction deadline')}</Text>
+    <Box mb="16px">
+      <Flex alignItems="center" mb="8px">
+        <Text bold>{translateString(90, 'Transaction deadline')}</Text>
         <QuestionHelper
           text={translateString(188, 'Your transaction will revert if it is pending for more than this long.')}
         />
-      </Label>
+      </Flex>
       <Field>
         <Input type="number" step="1" min="1" value={value} onChange={handleChange} />
-        <Text>Minutes</Text>
+        <Text fontSize="14px" ml="8px">
+          Minutes
+        </Text>
       </Field>
       {error && (
         <Text mt="8px" color="failure">
           {error}
         </Text>
       )}
-    </StyledTransactionDeadlineSetting>
+    </Box>
   )
 }
 

--- a/src/components/PageHeader/TransactionDeadlineSetting.tsx
+++ b/src/components/PageHeader/TransactionDeadlineSetting.tsx
@@ -29,11 +29,10 @@ const Field = styled.div`
 `
 
 type TransactionDeadlineSettingModalProps = {
-  translateString: (translationId: number, fallback: string) => (string)
+  translateString: (translationId: number, fallback: string) => string
 }
 
 const TransactionDeadlineSetting = ({ translateString }: TransactionDeadlineSettingModalProps) => {
-  const TranslateString = translateString
   const [deadline, setDeadline] = useUserDeadline()
   const [value, setValue] = useState(deadline / 60) // deadline in minutes
   const [error, setError] = useState<string | null>(null)
@@ -51,19 +50,19 @@ const TransactionDeadlineSetting = ({ translateString }: TransactionDeadlineSett
         setDeadline(rawValue)
         setError(null)
       } else {
-        setError(TranslateString(1150, 'Enter a valid deadline'))
+        setError(translateString(1150, 'Enter a valid deadline'))
       }
     } catch {
-      setError(TranslateString(1150, 'Enter a valid deadline'))
+      setError(translateString(1150, 'Enter a valid deadline'))
     }
-  }, [value, setError, setDeadline, TranslateString])
+  }, [value, setError, setDeadline, translateString])
 
   return (
     <StyledTransactionDeadlineSetting>
       <Label>
-        <Text style={{ fontWeight: 600 }}>{TranslateString(90, 'Transaction deadline')}</Text>
+        <Text style={{ fontWeight: 600 }}>{translateString(90, 'Transaction deadline')}</Text>
         <QuestionHelper
-          text={TranslateString(188, 'Your transaction will revert if it is pending for more than this long.')}
+          text={translateString(188, 'Your transaction will revert if it is pending for more than this long.')}
         />
       </Label>
       <Field>

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import styled from 'styled-components'
-import { Heading, IconButton, Text, Flex, useModal, Svg, TuneIcon } from '@pancakeswap-libs/uikit'
+import { Heading, IconButton, Text, Flex, useModal, TuneIcon, HistoryIcon } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 import SettingsModal from './SettingsModal'
 import RecentTransactionsModal from './RecentTransactionsModal'
@@ -10,15 +10,6 @@ interface PageHeaderProps {
   description?: ReactNode
   children?: ReactNode
 }
-
-const HistoryIcon = () => (
-  <Svg width="24" height="24" viewBox="0 0 24 24">
-    <path
-      d="M13 3C8.03 3 4 7.03 4 12H1L4.89 15.89L4.96 16.03L9 12H6C6 8.13 9.13 5 13 5C16.87 5 20 8.13 20 12C20 15.87 16.87 19 13 19C11.07 19 9.32 18.21 8.06 16.94L6.64 18.36C8.27 19.99 10.51 21 13 21C17.97 21 22 16.97 22 12C22 7.03 17.97 3 13 3ZM12 8V13L16.28 15.54L17 14.33L13.5 12.25V8H12Z"
-      fill="currentColor"
-    />
-  </Svg>
-)
 
 const StyledPageHeader = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.colors.borderColor};
@@ -53,7 +44,7 @@ const PageHeader = ({ title, description, children }: PageHeaderProps) => {
           onClick={onPresentRecentTransactions}
           title={TranslateString(1202, 'Recent transactions')}
         >
-          <HistoryIcon />
+          <HistoryIcon width="24px" color="currentColor" />
         </IconButton>
       </Flex>
       {children && <Text mt="16px">{children}</Text>}

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import styled from 'styled-components'
-import { Heading, IconButton, Text, Flex, useModal, CogIcon, Svg } from '@pancakeswap-libs/uikit'
+import { Heading, IconButton, Text, Flex, useModal, Svg, TuneIcon } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 import SettingsModal from './SettingsModal'
 import RecentTransactionsModal from './RecentTransactionsModal'
@@ -32,7 +32,7 @@ const Details = styled.div`
 const PageHeader = ({ title, description, children }: PageHeaderProps) => {
   const TranslateString = useI18n()
   const [onPresentSettings] = useModal(<SettingsModal translateString={TranslateString} />)
-  const [onPresentRecentTransactions] = useModal(<RecentTransactionsModal translateString={TranslateString}/>)
+  const [onPresentRecentTransactions] = useModal(<RecentTransactionsModal translateString={TranslateString} />)
 
   return (
     <StyledPageHeader>
@@ -46,7 +46,7 @@ const PageHeader = ({ title, description, children }: PageHeaderProps) => {
           )}
         </Details>
         <IconButton variant="text" onClick={onPresentSettings} title={TranslateString(1200, 'Settings')}>
-          <CogIcon width="24px" color="currentColor" />
+          <TuneIcon width="24px" color="currentColor" />
         </IconButton>
         <IconButton
           variant="text"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,11 +2122,13 @@
     tiny-warning "^1.0.3"
     toformat "^2.0.0"
 
-"@pancakeswap-libs/uikit@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@pancakeswap-libs/uikit/-/uikit-0.20.0.tgz#778b7849039255ee16904ef552ce9c9994e7d89d"
-  integrity sha512-erxEY3rm7O9oCERgS0yUgipCHH64D0vCH+ea+sVWtQc2o9tDQZ+U6MtLMqBqBmtLwEtWPAQhqL9DPwApTDaTCg==
+"@pancakeswap-libs/uikit@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@pancakeswap-libs/uikit/-/uikit-0.22.0.tgz#40fac0968ba249b41499ceaf3f89be21970a88a9"
+  integrity sha512-/R02s2Kxf5Xv5bQESD7vQeuuRQn+VOmYd5k3rzEB57LoQBUZtK/lmb2g9N6XYZK7t9DDVe8UrKIQI420gZcbgA==
   dependencies:
+    "@types/lodash" "^4.14.168"
+    "@types/styled-system" "^5.1.10"
     lodash "^4.17.20"
     react-transition-group "^4.4.1"
     styled-system "^5.1.5"
@@ -2632,7 +2634,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
+"@types/lodash@*", "@types/lodash@^4.14.168":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
@@ -2809,6 +2811,13 @@
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.10.tgz#dcf5690dd837ca49b8de1f23cb99d510c7f4ecb3"
   integrity sha512-OmVjC9OzyUckAgdavJBc+t5oCJrNXTlzWl9vo2x47leqpX1REq2qJC49SEtzbu1OnWSzcD68Uq3Aj8TeX+Kvtg==
+  dependencies:
+    csstype "^3.0.2"
+
+"@types/styled-system@^5.1.10":
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.11.tgz#158849f3b14cdf8bf27a10f0cf87a2c3a89eb680"
+  integrity sha512-R+JxEZYa5T0HD2urViR/mdklVaGhwbNOtDoWWGQ1+z1CGs/gF1UAKCaS//YwsUwterEKpyaKxgaXyFNKF04GCA==
   dependencies:
     csstype "^3.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,10 +2122,10 @@
     tiny-warning "^1.0.3"
     toformat "^2.0.0"
 
-"@pancakeswap-libs/uikit@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@pancakeswap-libs/uikit/-/uikit-0.22.0.tgz#40fac0968ba249b41499ceaf3f89be21970a88a9"
-  integrity sha512-/R02s2Kxf5Xv5bQESD7vQeuuRQn+VOmYd5k3rzEB57LoQBUZtK/lmb2g9N6XYZK7t9DDVe8UrKIQI420gZcbgA==
+"@pancakeswap-libs/uikit@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@pancakeswap-libs/uikit/-/uikit-0.23.0.tgz#34f70a9fdc5e22a68b01055eb34e332a39c1e43c"
+  integrity sha512-3R6KuXcS5NJ4BNT1zL17T1oUimyky8CpvTVo/fsSrYYudgq+ra5E5T7srvt+uQTOI0ZFiGn9WORmD/ecT6ZKjg==
   dependencies:
     "@types/lodash" "^4.14.168"
     "@types/styled-system" "^5.1.10"


### PR DESCRIPTION
This PR adds toggle that disables/enables audio effect on token selection. Surprisingly the whole sound effect muting/unmuting logic was already implemented long ago, the reducer had everything in place, even storing in localStorage. It just that there was no toggle, lol.

Also in this PR:
- tiny refactoring in 774891ccf390da1ecba4589b57d614bd068c3774
- fixed spacing between slippage buttons on mobile c154254
- change settings icon to TuneIcon
- use HistoryIcon from UIKit instead of re-declaring it
- CSS refactoring for TransactionDeadlineSettings and SlippageToleranceSetting

## Toggle on different screen sizes (+ fixed spacing on mobile layouts):
### Mobile
![Screenshot 2021-04-08 at 9 34 45](https://user-images.githubusercontent.com/81824236/113982152-15c5f580-9851-11eb-88ce-7a994a4c91a7.png)
![Screenshot 2021-04-08 at 9 34 30](https://user-images.githubusercontent.com/81824236/113982178-1f4f5d80-9851-11eb-89ae-be668b0711ce.png)
![Screenshot 2021-04-08 at 9 35 06](https://user-images.githubusercontent.com/81824236/113982213-27a79880-9851-11eb-8c6a-45510966f2cb.png)
![Screenshot 2021-04-08 at 9 35 18](https://user-images.githubusercontent.com/81824236/113982220-2a09f280-9851-11eb-96cf-ca054008b0d7.png)

### Desktop
![Screenshot 2021-04-08 at 9 38 17](https://user-images.githubusercontent.com/81824236/113982304-47d75780-9851-11eb-8868-3ccd83e26578.png)
![Screenshot 2021-04-08 at 9 38 08](https://user-images.githubusercontent.com/81824236/113982294-4574fd80-9851-11eb-8850-c90c811da1f0.png)
![Screenshot 2021-04-08 at 9 38 33](https://user-images.githubusercontent.com/81824236/113982364-5887cd80-9851-11eb-9842-a3d7e57f708b.png)
![Screenshot 2021-04-08 at 9 38 41](https://user-images.githubusercontent.com/81824236/113982380-5aea2780-9851-11eb-9832-30b9fbe10175.png)

## New Tune icon for settings (+ HistoryIcon coming from UIKit, it is the same)
![Screenshot 2021-04-08 at 9 40 37](https://user-images.githubusercontent.com/81824236/113982490-7bb27d00-9851-11eb-8dd1-6d18cc7f9335.png)
![Screenshot 2021-04-08 at 9 40 42](https://user-images.githubusercontent.com/81824236/113982493-7ce3aa00-9851-11eb-95ec-8da820467503.png)


### For context - wrong spacing on mobile (fixed version in images above):
![Screenshot 2021-04-06 at 16 05 31](https://user-images.githubusercontent.com/81824236/113715258-f6fd1d00-96f1-11eb-9322-6c76f5d55c66.png)

