### PR TITLE
feat(swap): Add warning for SafeDMT

### DIFF
--- a/src/components/SafeDMTWarningModal/index.tsx
+++ b/src/components/SafeDMTWarningModal/index.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback, useState } from 'react'
+import styled from 'styled-components'
+import { Button, Text } from '@pancakeswap-libs/uikit'
+import { AlertTriangle } from 'react-feather'
+import Modal from '../Modal'
+import { AutoRow, RowBetween } from '../Row'
+import { AutoColumn } from '../Column'
+
+const WarningContainer = styled.div`
+  max-width: 420px;
+  width: 100%;
+  padding: 1rem;
+  background: rgba(242, 150, 2, 0.05);
+  border: 1px solid #f3841e;
+  border-radius: 20px;
+  overflow: auto;
+`
+
+const StyledWarningIcon = styled(AlertTriangle)`
+  stroke: ${({ theme }) => theme.colors.binance};
+`
+
+export default function SafeDMTWarningModal({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) {
+  const [understandChecked, setUnderstandChecked] = useState(false)
+  const toggleUnderstand = useCallback(() => setUnderstandChecked((uc) => !uc), [])
+
+  const handleDismiss = useCallback(() => null, [])
+  return (
+    <Modal isOpen={isOpen} onDismiss={handleDismiss} maxHeight={90}>
+      <WarningContainer className="token-warning-container">
+        <AutoColumn gap="lg">
+          <AutoRow gap="6px">
+            <StyledWarningIcon />
+            <Text>Notice for trading SafeDMT</Text>
+          </AutoRow>
+          <>
+            <Text>
+              To trade SafeDMT, you must click on the settings icon and{' '}
+              <strong>set your slippage tolerance to 1%+</strong>
+            </Text>
+            <Text>
+              Also, <strong> the last digit of the desired amount of SafeDMT needs to be 1</strong>
+            </Text>
+            <Text>This is because otherwise the transaction may fail due to calculation issues.</Text>moon
+          </>
+          <RowBetween>
+            <div>
+              <label htmlFor="understand-checkbox" style={{ cursor: 'pointer', userSelect: 'none' }}>
+                <input
+                  id="understand-safeDMTWarning"
+                  type="checkbox"
+                  className="understand-checkbox"
+                  checked={understandChecked}
+                  onChange={toggleUnderstand}
+                />{' '}
+                <Text as="span">I understand</Text>
+              </label>
+            </div>
+            <Button
+              id="confirm-safeDMTWarning"
+              disabled={!understandChecked}
+              variant="danger"
+              style={{ width: '140px' }}
+              onClick={() => {
+                setUnderstandChecked(false)
+                onConfirm()
+              }}
+            >
+              Continue
+            </Button>
+          </RowBetween>
+        </AutoColumn>
+      </WarningContainer>
+    </Modal>
+  )
+}

--- a/src/components/SafeDMTWarningModal/index.tsx
+++ b/src/components/SafeDMTWarningModal/index.tsx
@@ -36,12 +36,12 @@ export default function SafeDMTWarningModal({ isOpen, onConfirm }: { isOpen: boo
           <>
             <Text>
               To trade SafeDMT, you must click on the settings icon and{' '}
-              <strong>set your slippage tolerance to 1%+</strong>
+              <strong>set your slippage tolerance to 5% or more</strong>
             </Text>
             <Text>
-              Also, <strong> the last digit of the desired amount of SafeDMT needs to be 1</strong>
+              Also, <strong>the last digit of the desired amount of SafeDMT needs to be 1</strong>
             </Text>
-            <Text>This is because otherwise the transaction may fail due to calculation issues.</Text>moon
+            <Text>This is because otherwise the transaction may fail due to calculation issues</Text>
           </>
           <RowBetween>
             <div>

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -293,7 +293,7 @@ const Swap = () => {
   // If so, they will be alerted with a warning message.
   const checkForWarning = useCallback(
     (selected: string, purchaseType: string) => {
-      if (['SYRUP', 'SAFEMOON', 'SAFEDMT'].includes(selected)) {
+      if (['SYRUP', 'SAFEMOON', 'SDMT'].includes(selected)) {
         setTransactionWarning({
           selectedToken: selected,
           purchaseType,
@@ -315,7 +315,7 @@ const Swap = () => {
       if (inputCurrency.symbol === 'SAFEMOON') {
         checkForWarning(inputCurrency.symbol, 'Selling')
       }
-      if (inputCurrency.symbol === 'SAFEDMT') {
+      if (inputCurrency.symbol === 'SDMT') {
         checkForWarning(inputCurrency.symbol, 'Selling')
       }
     },
@@ -339,7 +339,7 @@ const Swap = () => {
       if (outputCurrency.symbol === 'SAFEMOON') {
         checkForWarning(outputCurrency.symbol, 'Buying')
       }
-      if (outputCurrency.symbol === 'SAFEDMT') {
+      if (outputCurrency.symbol === 'SDMT') {
         checkForWarning(outputCurrency.symbol, 'Buying')
       }
     },
@@ -359,7 +359,7 @@ const Swap = () => {
         onConfirm={handleConfirmWarning}
       />
       <SafeMoonWarningModal isOpen={transactionWarning.selectedToken === 'SAFEMOON'} onConfirm={handleConfirmWarning} />
-      <SafeDMTWarningModal isOpen={transactionWarning.selectedToken === 'SAFEDMT'} onConfirm={handleConfirmWarning} />
+      <SafeDMTWarningModal isOpen={transactionWarning.selectedToken === 'SDMT'} onConfirm={handleConfirmWarning} />
       <CardNav />
       <AppBody>
         <Wrapper id="swap-page">

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -17,6 +17,7 @@ import TradePrice from 'components/swap/TradePrice'
 import TokenWarningModal from 'components/TokenWarningModal'
 import SyrupWarningModal from 'components/SyrupWarningModal'
 import SafeMoonWarningModal from 'components/SafeMoonWarningModal'
+import SafeDMTWarningModal from 'components/SafeDMTWarningModal'
 import ProgressSteps from 'components/ProgressSteps'
 import Container from 'components/Container'
 
@@ -288,11 +289,11 @@ const Swap = () => {
     setSwapState((prevState) => ({ ...prevState, tradeToConfirm: trade }))
   }, [trade])
 
-  // This will check to see if the user has selected Syrup or SafeMoon to either buy or sell.
+  // This will check to see if the user has selected Syrup, SafeMoon or SafeDMT to either buy or sell.
   // If so, they will be alerted with a warning message.
   const checkForWarning = useCallback(
     (selected: string, purchaseType: string) => {
-      if (['SYRUP', 'SAFEMOON'].includes(selected)) {
+      if (['SYRUP', 'SAFEMOON', 'SAFEDMT'].includes(selected)) {
         setTransactionWarning({
           selectedToken: selected,
           purchaseType,
@@ -312,6 +313,9 @@ const Swap = () => {
         checkForWarning(inputCurrency.symbol, 'Selling')
       }
       if (inputCurrency.symbol === 'SAFEMOON') {
+        checkForWarning(inputCurrency.symbol, 'Selling')
+      }
+      if (inputCurrency.symbol === 'SAFEDMT') {
         checkForWarning(inputCurrency.symbol, 'Selling')
       }
     },
@@ -335,6 +339,9 @@ const Swap = () => {
       if (outputCurrency.symbol === 'SAFEMOON') {
         checkForWarning(outputCurrency.symbol, 'Buying')
       }
+      if (outputCurrency.symbol === 'SAFEDMT') {
+        checkForWarning(outputCurrency.symbol, 'Buying')
+      }
     },
     [onCurrencySelection, checkForWarning]
   )
@@ -352,6 +359,7 @@ const Swap = () => {
         onConfirm={handleConfirmWarning}
       />
       <SafeMoonWarningModal isOpen={transactionWarning.selectedToken === 'SAFEMOON'} onConfirm={handleConfirmWarning} />
+      <SafeDMTWarningModal isOpen={transactionWarning.selectedToken === 'SAFEDMT'} onConfirm={handleConfirmWarning} />
       <CardNav />
       <AppBody>
         <Wrapper id="swap-page">


### PR DESCRIPTION
This is not a listing request, just a request for a warning modal. Please let me know if there's any additional work to be done.

This pull request adds a warning when trying to purchase [SafeDMT](https://safedmt.finance) in the exchange.

When trying to buy our token, we need to adjust the last digit in order to be able to purchase without failing transactions.
This seems fishy to new members, which is why I'd like to contribute a warning modal for our token.