### PR TITLE
fix: correct ticker for SPARTA

### DIFF
--- a/src/constants/token/pancakeswap.json
+++ b/src/constants/token/pancakeswap.json
@@ -220,7 +220,7 @@
     },
     {
       "name": "SPARTAN PROTOCOL TOKEN",
-      "symbol": "SPART",
+      "symbol": "SPARTA",
       "address": "0xe4ae305ebe1abe663f261bc00534067c80ad677c",
       "chainId": 56,
       "decimals": 18,


### PR DESCRIPTION
Resolves #415 by changing the symbol value to SPARTA
